### PR TITLE
Fix mistake in docs

### DIFF
--- a/docs/source/checkpoint.rst
+++ b/docs/source/checkpoint.rst
@@ -26,7 +26,7 @@ SFT
       --dataset Open-Orca/OpenOrca \
       --input_key question \
       --output_key response \
-      --input_template 'User: {}\nAssistant: ' \
+      --input_template $'User: {}\nAssistant: ' \
       --train_batch_size 256 \
       --micro_train_batch_size 2 \
       --max_samples 500000 \

--- a/docs/source/non_rl.rst
+++ b/docs/source/non_rl.rst
@@ -63,7 +63,7 @@ Kahneman-Tversky Optimization (KTO)
       --input_key instruction \
       --output_key response \
       --label_key score \
-      --input_template 'User: {}\nAssistant: ' \
+      --input_template $'User: {}\nAssistant: ' \
       --flash_attn \
       --beta 0.1 \
       --gradient_checkpointing \
@@ -377,7 +377,7 @@ Knowledge Distillation (MiniLLM)
       --dataset Open-Orca/OpenOrca \
       --input_key question \
       --output_key response \
-      --input_template 'User: {}\nAssistant: ' \
+      --input_template $'User: {}\nAssistant: ' \
       --train_batch_size 256 \
       --micro_train_batch_size 2 \
       --max_samples 500000 \

--- a/docs/source/rl.rst
+++ b/docs/source/rl.rst
@@ -33,7 +33,7 @@ Datasets
 - ``--dataset_probs``: Dataset mixing probabilities
 - ``--input_key``: Input JSON key for conversions
 - ``--apply_chat_template``: Use HuggingFace ``tokenizer.apply_chat_template``
-- ``--input_template``: Custom ``input_template`` (when not using ``tokenizer.apply_chat_template``), set to ``None`` to disable it. Such as ``'User: {}\nAssistant: '``.
+- ``--input_template``: Custom ``input_template`` (when not using ``tokenizer.apply_chat_template``), set to ``None`` to disable it. Such as ``$'User: {}\nAssistant: '``.
 - ``--max_len``: Max length for the samples
 - ``--max_samples``: Max training samples
 - ``--train_split``: HF datasets split for training, default value is ``train``
@@ -58,7 +58,7 @@ Supervised Fine-tuning
       --dataset Open-Orca/OpenOrca \
       --input_key question \
       --output_key response \
-      --input_template 'User: {}\nAssistant: ' \
+      --input_template $'User: {}\nAssistant: ' \
       --train_batch_size 256 \
       --micro_train_batch_size 8 \
       --max_samples 500000 \


### PR DESCRIPTION
--input_template '\n' sends two chars to python: '\\' and 'n', rather than a newline char. The correct syntax is --input_template $'\n'.

See related PR in main repo: https://github.com/OpenRLHF/OpenRLHF/pull/518