### PR TITLE
Tiny update demo of REINFORCE/RLOO where critic seems not needed

### DIFF
--- a/docs/source/rl.rst
+++ b/docs/source/rl.rst
@@ -336,7 +336,6 @@ In REINFORCE-like algorithms, the value network is not used; instead, advantage 
       --zero_stage 3 \
       --bf16 \
       --actor_learning_rate 5e-7 \
-      --critic_learning_rate 9e-6 \
       --init_kl_coef 0.01 \
       --advantage_estimator reinforce \
       --prompt_data OpenRLHF/prompt-collection-v0.1 \


### PR DESCRIPTION
Hi thanks for the library! If I understand correctly, it seems that REINFORCE/RLOO does not use a critic model (and things like critic_num_nodes and critic_num_gpus_per_node are not specified in the demo). Therefore, it seems the critic_learning_rate also do not need to be specified.